### PR TITLE
Fix the month value to display.

### DIFF
--- a/app/src/main/java/com/devrel/android/fitactions/home/FitStatsAdapter.kt
+++ b/app/src/main/java/com/devrel/android/fitactions/home/FitStatsAdapter.kt
@@ -75,7 +75,7 @@ class FitStatsAdapter : ListAdapter<FitActivity, FitStatsAdapter.ViewHolder>(DIF
                 R.string.stat_date,
                 day,
                 calendar.get(Calendar.DAY_OF_MONTH),
-                calendar.get(Calendar.MONTH)
+                calendar.get(Calendar.MONTH) + 1
             )
 
             val minutes = TimeUnit.MILLISECONDS.toMinutes(activity.durationMs)

--- a/app/src/main/java/com/devrel/android/fitactions/home/FitStatsAdapter.kt
+++ b/app/src/main/java/com/devrel/android/fitactions/home/FitStatsAdapter.kt
@@ -26,6 +26,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.devrel.android.fitactions.R
 import com.devrel.android.fitactions.model.FitActivity
 import kotlinx.android.synthetic.main.fit_stats_row.view.*
+import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -71,11 +72,12 @@ class FitStatsAdapter : ListAdapter<FitActivity, FitStatsAdapter.ViewHolder>(DIF
                 Calendar.LONG,
                 Locale.getDefault()
             )
+            val monthFormatter = SimpleDateFormat("MM")
             itemView.statsRowTitle.text = context.getString(
                 R.string.stat_date,
                 day,
                 calendar.get(Calendar.DAY_OF_MONTH),
-                calendar.get(Calendar.MONTH) + 1
+                monthFormatter.format(calendar.time).toInt()
             )
 
             val minutes = TimeUnit.MILLISECONDS.toMinutes(activity.durationMs)


### PR DESCRIPTION
## What is This

This pull request fixes the issue which each month value is displayed as "Zero Origin" value.

## Detail

Currently, each result has a month/date value and it is displayed the main activity. But, each month value is displayed as "Zero Origin" month value. For example, if the month is May, it is displayed as "4". The correct value should be "5".

![Screenshot_20200524_140304](https://user-images.githubusercontent.com/261787/82746186-f1dbfb80-9dc7-11ea-93f5-b3b49e310b39.png)
