### PR TITLE
Fix: R class reference error.(for codelab-start branch)

### DIFF
--- a/app/src/main/java/com/devrel/android/fitactions/FitMainActivity.kt
+++ b/app/src/main/java/com/devrel/android/fitactions/FitMainActivity.kt
@@ -15,6 +15,8 @@
  *
  */
 
+package com.devrel.android.fitactions
+
 import android.app.assist.AssistContent
 import android.content.Intent
 import android.net.Uri


### PR DESCRIPTION
Fix: R class reference error. because package no specify.

<img width="956" alt="スクリーンショット 2022-06-17 17 34 24" src="https://user-images.githubusercontent.com/16476224/174261232-a40022be-49fe-4e66-befe-70ae60756260.png">

# Android Studio Version

<img width="609" alt="スクリーンショット 2022-06-17 17 39 33" src="https://user-images.githubusercontent.com/16476224/174261309-608740e9-71f4-40ec-a055-328be5cb3654.png">

